### PR TITLE
fix: check if data already exists on IPFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,8 @@ script under `./scripts/generate-jwt.ts`. You can call it using:
 pnpm generate-jwt $SCOPE
 ```
 
-Where `$SCOPE` is the scope/role you want the generated JWT to have.
+Where `$SCOPE` is the scope/role you want the generated JWT to have (use `ipfs`
+to test the `/data/ipfs` API, and `s3` for `/data/s3/json`).
 
 If you instead want to test the `/data/s3/templates` API to upload templates to
 limbo storage, you need to use the `./scripts/upload-folder.ts` script. This is

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,6 @@ services:
       - 9000:9000
       - 9001:9001
     environment:
-      - MINIO_ROOT_USER=user
-      - MINIO_ROOT_PASSWORD=password
+      - MINIO_ROOT_USER=data-manager-test-access-key
+      - MINIO_ROOT_PASSWORD=data-manager-test-secret-key
       - MINIO_DEFAULT_BUCKETS=data-manager-test-bucket


### PR DESCRIPTION
Check if the data already exists on IPFS, meaning it was already replicated from `s3`. Since the w3p client now reads from the `stored` data it needs a new `store/get` claim.